### PR TITLE
Render markdown in the terminal.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ const enchannel = require('enchannel-zmq-backend');
 const uuid = require('uuid');
 const chalk = require('chalk');
 
+const marked = require('marked');
+const TerminalRenderer = require('marked-terminal');
+
 // TODO: Launch a kernel
 // For now, rely on an argument for a kernel runtime
 const kernel = require(process.argv[2]);
@@ -49,6 +52,10 @@ function isChildMessage(msg) {
 function startREPL(langInfo) {
   const rl = readline.createInterface(process.stdin, process.stdout);
   const iopub = enchannel.createIOPubSubject(identity, kernel);
+
+  marked.setOptions({
+    renderer: new TerminalRenderer(),
+  });
 
   rl.setPrompt(`ick${langInfo.file_extension}> `);
   rl.prompt();
@@ -94,7 +101,10 @@ function startREPL(langInfo) {
     });
 
     displayData.subscribe(data => {
-      if(data['text/plain']) {
+      if(data['text/markdown']) {
+        console.log(marked(data['text/markdown']));
+      }
+      else if(data['text/plain']) {
         console.log(data['text/plain']);
       }
     });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "enchannel-zmq-backend": "^0.4.0",
+    "marked": "^0.3.5",
+    "marked-terminal": "^1.6.1",
     "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
Used [marked-terminal](https://github.com/mikaelbr/marked-terminal) to implement the text/markdown mimetype

## `ick`

![screenshot 2016-01-17 22 30 23](https://cloud.githubusercontent.com/assets/836375/12383280/b6eef902-bd69-11e5-92e6-6325ddb54e33.png)

## `ipython`

![screenshot 2016-01-17 22 28 08](https://cloud.githubusercontent.com/assets/836375/12383250/62eac2f0-bd69-11e5-8530-a63d236a4215.png)
