### PR TITLE
Display images inline as ANSI text.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "enchannel-zmq-backend": "^0.4.0",
+    "image-to-ascii": "^2.3.1",
     "marked": "^0.3.5",
     "marked-terminal": "^1.6.1",
+    "temp": "^0.8.3",
     "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
![screenshot 2016-01-17 23 22 51](https://cloud.githubusercontent.com/assets/836375/12383890/2713a7f8-bd71-11e5-8018-b2d353ffed6e.png)

This is crazy.

To get this one working, you'll need to [install graphicsmagick following these directions](https://github.com/IonicaBizau/image-to-ascii#installation).

Now you can plot in your terminal. Some images don't work and some work better than others.

![screenshot 2016-01-17 23 32 07](https://cloud.githubusercontent.com/assets/836375/12383971/5e17e0b0-bd72-11e5-9d8e-cef28f39d2d9.png)

![screenshot 2016-01-17 23 35 03](https://cloud.githubusercontent.com/assets/836375/12384001/bdeb5c4c-bd72-11e5-9a3c-51ed5c3b519d.png)
